### PR TITLE
fix for raven exports

### DIFF
--- a/DeepSqueak.m
+++ b/DeepSqueak.m
@@ -471,8 +471,7 @@ function folders_Callback(hObject, eventdata, handles)
 function export_raven_Callback(hObject, eventdata, handles)
 % Export current file as a txt file for viewing in Raven
 % http://www.birds.cornell.edu/brp/raven/RavenOverview.html
-handles.current_file_id = get(handles.popupmenuDetectionFiles,'Value');
-current_detection_file = handles.detectionfiles(handles.current_file_id).name;
+
 raventable = [{'Selection'} {'View'} {'Channel'} {'Begin Time (s)'} {'End Time (s)'} {'Low Freq (Hz)'} {'High Freq (Hz)'} {'Delta Time (s)'} {'Delta Freq (Hz)'} {'Avg Power Density (dB FS)'} {'Annotation'} {'Begin Path'} {'File Offset'}];
 View = 'Spectrogram 1';
 Channel = 1;
@@ -493,6 +492,8 @@ for i = 1:height(handles.data.calls)
     end
 end
 a  = cell2table(raventable);
+handles.current_file_id = get(handles.popupmenuDetectionFiles,'Value');
+current_detection_file = handles.detectionfiles(handles.current_file_id).name;
 ravenname=[strtok(current_detection_file,'.') '_Raven.txt'];
 [FileName,PathName] = uiputfile(ravenname,'Save Raven Truth Table (.txt)');
 writetable(a,[PathName FileName],'delimiter','\t','WriteVariableNames',false);

--- a/DeepSqueak.m
+++ b/DeepSqueak.m
@@ -471,7 +471,6 @@ function folders_Callback(hObject, eventdata, handles)
 function export_raven_Callback(hObject, eventdata, handles)
 % Export current file as a txt file for viewing in Raven
 % http://www.birds.cornell.edu/brp/raven/RavenOverview.html
-
 raventable = [{'Selection'} {'View'} {'Channel'} {'Begin Time (s)'} {'End Time (s)'} {'Low Freq (Hz)'} {'High Freq (Hz)'} {'Delta Time (s)'} {'Delta Freq (Hz)'} {'Avg Power Density (dB FS)'} {'Annotation'} {'Begin Path'} {'File Offset'}];
 View = 'Spectrogram 1';
 Channel = 1;

--- a/DeepSqueak.m
+++ b/DeepSqueak.m
@@ -471,7 +471,9 @@ function folders_Callback(hObject, eventdata, handles)
 function export_raven_Callback(hObject, eventdata, handles)
 % Export current file as a txt file for viewing in Raven
 % http://www.birds.cornell.edu/brp/raven/RavenOverview.html
-raventable = [{'Selection'} {'View'} {'Channel'} {'Begin Time (s)'} {'End Time (s)'} {'Low Freq (Hz)'} {'High Freq (Hz)'} {'Delta Time (s)'} {'Delta Freq (Hz)'} {'Avg Power Density (dB FS)'} {'Annotation'}];
+handles.current_file_id = get(handles.popupmenuDetectionFiles,'Value');
+current_detection_file = handles.detectionfiles(handles.current_file_id).name;
+raventable = [{'Selection'} {'View'} {'Channel'} {'Begin Time (s)'} {'End Time (s)'} {'Low Freq (Hz)'} {'High Freq (Hz)'} {'Delta Time (s)'} {'Delta Freq (Hz)'} {'Avg Power Density (dB FS)'} {'Annotation'} {'Begin Path'} {'File Offset'}];
 View = 'Spectrogram 1';
 Channel = 1;
 for i = 1:height(handles.data.calls)
@@ -485,12 +487,12 @@ for i = 1:height(handles.data.calls)
         DeltaFreq = HighFreq - LowFreq;
         AvgPwr = 1;
         Annotation = handles.data.calls.Accept(i);
-        raventable = [raventable; {Selection} {View} {Channel} {BeginTime} {EndTime} {LowFreq} {HighFreq} {DeltaTime} {DeltaFreq} {AvgPwr} {Annotation}];
+        BeginPath = handles.data.audiodata.Filename
+        FileOffset = handles.data.calls.Box(i, 1);
+        raventable = [raventable; {Selection} {View} {Channel} {BeginTime} {EndTime} {LowFreq} {HighFreq} {DeltaTime} {DeltaFreq} {AvgPwr} {Annotation} {BeginPath} {FileOffset}];
     end
 end
 a  = cell2table(raventable);
-handles.current_file_id = get(handles.popupmenuDetectionFiles,'Value');
-current_detection_file = handles.detectionfiles(handles.current_file_id).name;
 ravenname=[strtok(current_detection_file,'.') '_Raven.txt'];
 [FileName,PathName] = uiputfile(ravenname,'Save Raven Truth Table (.txt)');
 writetable(a,[PathName FileName],'delimiter','\t','WriteVariableNames',false);

--- a/DeepSqueak.m
+++ b/DeepSqueak.m
@@ -485,7 +485,7 @@ for i = 1:height(handles.data.calls)
         DeltaFreq = HighFreq - LowFreq;
         AvgPwr = 1;
         Annotation = handles.data.calls.Accept(i);
-        BeginPath = handles.data.audiodata.Filename
+        BeginPath = handles.data.audiodata.Filename;
         FileOffset = handles.data.calls.Box(i, 1);
         raventable = [raventable; {Selection} {View} {Channel} {BeginTime} {EndTime} {LowFreq} {HighFreq} {DeltaTime} {DeltaFreq} {AvgPwr} {Annotation} {BeginPath} {FileOffset}];
     end


### PR DESCRIPTION
Quick fix for exports to Raven Pro 1.6.

Previous exports lacked "Begin Path" (e.g. full path of audio file) and "FileOffset" (e.g. start time of each detected sound as measured from the start of the file).

"FileOffset" is accurate so long as the files are analyzed from the start of the file forward (which is currently always the case).