### PR TITLE
ExtContourBug

### DIFF
--- a/Functions/Call Classification/CreateClusteringData.m
+++ b/Functions/Call Classification/CreateClusteringData.m
@@ -64,7 +64,7 @@ for j = 1:length(fileName)
 end
 
 % Optimize the window size so that the pixels are square on average
-if isempty(spectrogramOptions)
+if isempty(spectrogramOptions) && ~isempty(Calls)
     yRange = mean(Calls.Box(:,4));
     xRange = mean(Calls.Box(:,3));
     noverlap = .5;


### PR DESCRIPTION
Hey again Kevin - Just found and fixed small bug that was crashing without a Calls table when Extracted Contours is loaded instead of a detections mat during clustering, but I don't know how important it is to set those spectrogramOptions, so maybe you have another way you want to get at yrange and xrange?